### PR TITLE
Fix full overlap elimination for inserts

### DIFF
--- a/src/dmp.rs
+++ b/src/dmp.rs
@@ -1300,7 +1300,7 @@ impl DiffMatchPatch {
                     if p_prev < diffs.len() && del_idx_end <= delete.len() {
                         diffs[p_prev].1 = delete[..del_idx_end].to_vec();
                     }
-                    if p_next < diffs.len() && overlap_1 < insert.len() {
+                    if p_next < diffs.len() && overlap_1 <= insert.len() {
                         diffs[p_next].1 = insert[overlap_1..].to_vec();
                     }
                     pointer += 1;
@@ -4459,6 +4459,37 @@ mod tests {
         ];
         DiffMatchPatch::cleanup_semantic(&mut diffs);
         assert_eq!(test, diffs);
+
+        // overlap that fully eliminates an delete
+        let mut diffs = vec![
+            Diff::delete(&"abcd".chars().collect::<Vec<_>>()[..]),
+            Diff::insert(&"abcd1212".chars().collect::<Vec<_>>()[..]),
+            Diff::equal(&"wxyz".chars().collect::<Vec<_>>()[..]),    
+        ];
+        let test = vec![
+            Diff::delete(&"".chars().collect::<Vec<_>>()[..]),
+            Diff::equal(&"abcd".chars().collect::<Vec<_>>()[..]),
+            Diff::insert(&"1212".chars().collect::<Vec<_>>()[..]),
+            Diff::equal(&"wxyz".chars().collect::<Vec<_>>()[..]),    
+        ];
+        DiffMatchPatch::cleanup_semantic(&mut diffs);
+        assert_eq!(test, diffs);
+
+        // overlap that fully eliminates an insert
+        let mut diffs = vec![
+            Diff::delete(&"abcd1212".chars().collect::<Vec<_>>()[..]),
+            Diff::insert(&"1212".chars().collect::<Vec<_>>()[..]),
+            Diff::equal(&"wxyz".chars().collect::<Vec<_>>()[..]),    
+        ];
+        let test = vec![
+            Diff::delete(&"abcd".chars().collect::<Vec<_>>()[..]),
+            Diff::equal(&"1212".chars().collect::<Vec<_>>()[..]),
+            Diff::insert(&"".chars().collect::<Vec<_>>()[..]),
+            Diff::equal(&"wxyz".chars().collect::<Vec<_>>()[..]),    
+        ];
+        DiffMatchPatch::cleanup_semantic(&mut diffs);
+        assert_eq!(test, diffs);
+
     }
 
     #[test]


### PR DESCRIPTION
In cases where there's a full overlap elimination for an insert (e.g., when there's a delete followed by a insert that completely overlaps the tail of the delete), the overlap is replaced by an equal covering the overlap, and the insert should be changed to zero-length.

This adds a test for this overlap case for inserts (and the corresponding overlap case for deletes), and it fixes a bug with the insert case.